### PR TITLE
Add value iteration and changes to enable it

### DIFF
--- a/muzero/envs/line.py
+++ b/muzero/envs/line.py
@@ -1,0 +1,32 @@
+import gym
+
+
+class Line(gym.Env):
+    """A simple environment for testing.
+
+    - State space consists of cells on a line, where you start on the left and end on the right.
+        State 0 is furthest to the left, state `length - 1` is furthest to the right.
+    - Action space is move left / right.
+    - Transition model is deterministic; stationary if walls prevent action.
+    - Reward model is +10 for reaching the end, -1 for each action.
+    - Discount factor is 1.0.
+    """
+
+    def __init__(self, length=5):
+        self.length = length
+        self.finish_reward = 10
+        self.act_reward = -1
+        self.observation_space = gym.spaces.Discrete(length)
+        self.action_space = gym.spaces.Discrete(2)
+        self.discount = 1.0
+
+    def transitions(self, state, action):
+        dx = 1 if action == 0 else -1
+        next_state = min(max(state + dx, 0), self.length - 1)
+        terminal = state == self.length - 1
+        if terminal:
+            reward = self.finish_reward if next_state == self.length - 1 else 0
+        else:
+            reward = self.act_reward
+        prob = 1.0
+        return [(next_state, reward, terminal, prob)]

--- a/muzero/planning/spaces_util.py
+++ b/muzero/planning/spaces_util.py
@@ -1,0 +1,42 @@
+import gym
+import numpy as np
+
+
+def _make_not_implemented_error(space):
+    return NotImplementedError("Space of type {} not implemented.".format(type(space)))
+
+
+def get_space_size(space):
+    if isinstance(space, gym.spaces.Discrete):
+        return space.n
+    elif isinstance(space, gym.spaces.MultiDiscrete):
+        return np.prod(space.nvec)
+    else:
+        raise _make_not_implemented_error(space)
+
+
+def get_index_to_space_converter(space):
+    if isinstance(space, gym.spaces.Discrete):
+        return lambda x: x
+    elif isinstance(space, gym.spaces.MultiDiscrete):
+
+        def _converter(index):
+            return np.unravel_index(index, space.nvec)
+
+        return _converter
+    else:
+        raise _make_not_implemented_error(space)
+
+
+def get_space_to_index_converter(space):
+    if isinstance(space, gym.spaces.Discrete):
+        return lambda x: x
+    elif isinstance(space, gym.spaces.MultiDiscrete):
+
+        def _converter(element):
+            return np.ravel_multi_index(element, space.nvec)
+
+        return _converter
+
+    else:
+        raise _make_not_implemented_error(space)

--- a/muzero/planning/value_iteration.py
+++ b/muzero/planning/value_iteration.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+import muzero.planning.spaces_util as spaces_util
+
+
+def value_iteration(mdp, max_iter, tol=1e-4, verbose=True):
+    num_states = spaces_util.get_space_size(mdp.observation_space)
+    i2s = spaces_util.get_index_to_space_converter(mdp.observation_space)
+    s2i = spaces_util.get_space_to_index_converter(mdp.observation_space)
+    num_actions = spaces_util.get_space_size(mdp.action_space)
+    i2a = spaces_util.get_index_to_space_converter(mdp.action_space)
+
+    v = np.zeros(num_states)
+    pi = np.empty(num_states, dtype=int)
+    for itr in range(max_iter):
+        residual = 0
+        for s in range(num_states):
+            max_value = -np.inf
+            best_a = 0
+            for a in range(num_actions):
+                cur_value = 0
+                for sp, r, t, p in mdp.transitions(i2s(s), i2a(a)):
+                    cur_value += p * r
+                    if not t:
+                        cur_value += p * mdp.discount * v[s2i(sp)]
+                if cur_value > max_value:
+                    max_value = cur_value
+                    best_a = a
+            assert max_value != -np.inf, "Max value was not set"
+            residual = max(residual, abs(v[s] - max_value))
+            v[s] = max_value
+            pi[s] = best_a
+        if verbose:
+            print("itr: {} / {} residual: {}".format(itr + 1, max_iter, residual))
+        if residual < tol:
+            break
+
+    # Convert to a format reconginzable by the mdp.
+    v_dict = dict()
+    pi_dict = dict()
+    for s in range(num_states):
+        v_dict[i2s(s)] = v[s]
+        pi_dict[i2s(s)] = pi[s]
+    return v, pi, v_dict, pi_dict

--- a/scripts/compare_planning_algorithms.py
+++ b/scripts/compare_planning_algorithms.py
@@ -1,0 +1,18 @@
+from muzero.envs.maze import Maze
+from muzero.planning.value_iteration import value_iteration
+
+
+def run_value_iteration(env):
+    _, _, v, pi = value_iteration(env, max_iter=100)
+    return v, pi
+
+
+def main():
+    env = Maze()
+    v, pi = run_value_iteration(env)
+    env.render_value_function(v)
+    print(pi)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/planning/test_value_iteration.py
+++ b/tests/planning/test_value_iteration.py
@@ -1,0 +1,26 @@
+import unittest
+
+import numpy as np
+
+from muzero.envs.line import Line
+from muzero.envs.maze import Maze
+from muzero.planning.value_iteration import value_iteration
+
+
+class TestValueIteration(unittest.TestCase):
+    def test_on_line_env(self):
+        env = Line()
+        v, pi, _, _ = value_iteration(env, max_iter=env.length, verbose=False)
+        np.testing.assert_array_almost_equal(v, [6, 7, 8, 9, 10])
+        np.testing.assert_array_almost_equal(pi, np.zeros_like(pi))
+
+    def test_on_maze_env(self):
+        env = Maze()
+        _, _, v, pi = value_iteration(env, max_iter=100, verbose=False)
+        self.assertAlmostEqual(v[(4, 4)], 1)
+        self.assertAlmostEqual(v[(5, 0)], -1)
+        self.assertAlmostEqual(v[(0, 0)], 0.9227, 3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit adds an implementation of value iteration, and makes
to enable its use. For example, the maze environment has some
methods added to it, an even simpler test environment is added
that models moving along a line, and a test is created.